### PR TITLE
Fix erroroneous key combination in window cycling.

### DIFF
--- a/UsingKorora/DesktopSpecific/Cinnamon-Shortcuts.md
+++ b/UsingKorora/DesktopSpecific/Cinnamon-Shortcuts.md
@@ -95,11 +95,11 @@ If Cinnamon has become buggy or unusable, you can try restarting it via the foll
 
 To cycle from left to right, use:
 
-    Ctrl + Tab
+    Alt + Tab
 
 To cycle in the reverse direction, use:
 
-    Ctrl + Shift + Tab
+    Alt + Shift + Tab
 
 ### Cycle between open instances of the same application
 


### PR DESCRIPTION
This PR fixes an earlier PR that incorrectly listed `Ctrl + Tab` as the shortcut for cycling windows instead of `Alt + Tab`. `Ctrl + Tab` is used for cycling tabs and is a valid shortcut, but was excluded from the article as it is application-specific. 