### PR TITLE
Expand Software Tour into desktop-specific guides.

### DIFF
--- a/UsingKorora/DesktopSpecific/Cinnamon-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/Cinnamon-Tour-of-Software.md
@@ -1,7 +1,6 @@
 **Table of Contents**  
 
-- [Tour of Korora Software ("I Need a Program That Does This")](#tour-of-korora-software-i-need-a-program-that-does-this)
-- [Common Packages and Desktop Differences](#common-packages-and-desktop-differences)
+- [Tour of Cinnamon Software ("I Need a Program That Does This")](#tour-of-cinnamon-software-i-need-a-program-that-does-this)
 - [Office Applications](#office-applications)
 - [Image Editor](#image-editor)
 - [Image Viewers](#image-viewers)
@@ -22,26 +21,12 @@
 
 
 
-<a name="tour-of-korora-software-i-need-a-program-that-does-this"></a>
-# Tour of Korora Software ("I Need a Program That Does This")
+<a name="tour-of-cinnamon-software-i-need-a-program-that-does-this"></a>
+# Tour of Cinnamon Software ("I Need a Program That Does This")
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
-<a name="common-packages-and-desktop-differences"></a>
-## Common Packages and Desktop Differences
-
-Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
-
-**GTK-based desktops**:
-- [GNOME](GNOME-Tour-of-Software.md)
-- [Cinnamon](Cinnamon-Tour-of-Software.md)
-- [MATE](MATE-Tour-of-Software.md)
-- [Xfce](Xfce-Tour-of-Software.md)
-
-**Qt-based desktops**:
-- [KDE](KDE-Tour-of-Software.md)
-
-Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
+The Cinnamon desktop pulls most of its preinstalled programs from GNOME, with a handful of other additions from the upstream [Linux Mint](https://linuxmint.com/) project that develops the Cinnamon desktop. There are also some programs added by Korora.
 
 <a name="office-applications"></a>
 ## Office Applications
@@ -51,40 +36,53 @@ Because of KDE's significant differences, we cannot list many packages on this p
 - [LibreOffice Draw](https://www.libreoffice.org/discover/draw/) (Image and flowchart editor, like Microsoft Visio)
 - [LibreOffice Impress](https://www.libreoffice.org/discover/impress/) (Presentation and slide editor, like Microsoft Powerpoint)
 - [Project Management](https://wiki.gnome.org/Apps/Planner) (plan projects)
+- [GNote](https://wiki.gnome.org/Apps/Gnote) (write short sticky-notes of information)
 
 <a name="image-editor"></a>
 ## Image Editor 
 **PURPOSE**: I Need to Touch Up Some Photos
 - [GIMP](https://www.gimp.org/)
+- [Darktable](http://www.darktable.org/) (Photography and RAW photo developer)
 - [Inkscape](https://inkscape.org/) (Vector graphics editor)
 - [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
 
 <a name="image-viewers"></a>
 ## Image Viewers
 **PURPOSE**: I Just Want to Look at Some Photos
+- [Eye of GNOME](https://wiki.gnome.org/Apps/EyeOfGnome) (Under the name "Image Viewer")
+- [Shotwell](https://wiki.gnome.org/Apps/Shotwell) (Photo Manger)
 
 <a name="pdf-readers"></a>
 ## PDF Readers
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="e-readers"></a>
 ## E-Readers 
+- [FBReader](https://fbreader.org/) (E-book and Comic Book reader)
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="rss-reader"></a>
 ## RSS Reader
+- [Liferea](http://lzone.de/liferea/)
 
 <a name="scanners"></a>
 ## Scanners 
 **PURPOSE**: I Need to Scan a Document
+- [Simple Scan](https://launchpad.net/simple-scan)
 
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
 - [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
+- [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox/) (Audio player)
 
 <a name="multimedia-ripping-and-conversion"></a>
 ## Multimedia Ripping and Conversion
 **PURPOSE**: I Need to Rip My CD or DVD
+- [Brasero](https://wiki.gnome.org/Apps/Brasero) (copies and burns CDs and DVDs)
 - [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blurays)
+- [Sound Juicer](https://wiki.gnome.org/Apps/SoundJuicer) (rips audio CDs to your hard-drive)
+- [Sound Converter](http://soundconverter.org) (Converts audio files to other formats)
 
 <a name="desktop-recording"></a>
 ## Desktop Recording
@@ -93,6 +91,7 @@ Because of KDE's significant differences, we cannot list many packages on this p
 <a name="sound-and-video-editing"></a>
 ## Sound and Video Editing
 - [Audacity](http://www.audacityteam.org/) (audio editing program)
+- [Pitivi](http://www.pitivi.org/) (video editing program)
 
 <a name="internet"></a>
 ## Internet
@@ -100,17 +99,24 @@ Because of KDE's significant differences, we cannot list many packages on this p
 
 <a name="e-mail"></a>
 ## E-Mail
+- [Thunderbird](https://www.mozilla.org/en-US/thunderbird/)
 
 <a name="audiovisual-communication"></a>
 ## Audiovisual Communication
 **PURPOSE**: I Need to Call / Video Conference With Someone
+- [Ekiga Softphone](http://www.ekiga.org)
 
 <a name="chat-applications"></a>
 ## Chat Applications
+- [Pidgin](https://pidgin.im/) (IM app, has compatibility with AIM, Google Talk, XMPP, etc.)
+- [HexChat](https://hexchat.github.io/) (IRC Client)
 
 <a name="torrent-client"></a>
 ## Torrent Client
+- [Transmission](http://www.transmissionbt.com/)
 
 <a name="system-applications"></a>
 ## System Applications
+- [GParted](http://gparted.org) (Modify and delete system partitions)
+- [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)

--- a/UsingKorora/DesktopSpecific/GNOME-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/GNOME-Tour-of-Software.md
@@ -1,7 +1,6 @@
 **Table of Contents**  
 
-- [Tour of Korora Software ("I Need a Program That Does This")](#tour-of-korora-software-i-need-a-program-that-does-this)
-- [Common Packages and Desktop Differences](#common-packages-and-desktop-differences)
+- [Tour of GNOME Software ("I Need a Program That Does This")](#tour-of-gnome-software-i-need-a-program-that-does-this)
 - [Office Applications](#office-applications)
 - [Image Editor](#image-editor)
 - [Image Viewers](#image-viewers)
@@ -22,26 +21,14 @@
 
 
 
-<a name="tour-of-korora-software-i-need-a-program-that-does-this"></a>
-# Tour of Korora Software ("I Need a Program That Does This")
+<a name="tour-of-gnome-software-i-need-a-program-that-does-this"></a>
+# Tour of GNOME Software ("I Need a Program That Does This")
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
-<a name="common-packages-and-desktop-differences"></a>
-## Common Packages and Desktop Differences
+The GNOME desktop pulls all of its packages from [The GNOME Project](https://www.gnome.org/), its maintainers. These programs are usually built in-house and do not pull "upstream" from anywhere else.
 
-Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
-
-**GTK-based desktops**:
-- [GNOME](GNOME-Tour-of-Software.md)
-- [Cinnamon](Cinnamon-Tour-of-Software.md)
-- [MATE](MATE-Tour-of-Software.md)
-- [Xfce](Xfce-Tour-of-Software.md)
-
-**Qt-based desktops**:
-- [KDE](KDE-Tour-of-Software.md)
-
-Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
+On top of this, there are additional packages added by Korora.
 
 <a name="office-applications"></a>
 ## Office Applications
@@ -51,40 +38,54 @@ Because of KDE's significant differences, we cannot list many packages on this p
 - [LibreOffice Draw](https://www.libreoffice.org/discover/draw/) (Image and flowchart editor, like Microsoft Visio)
 - [LibreOffice Impress](https://www.libreoffice.org/discover/impress/) (Presentation and slide editor, like Microsoft Powerpoint)
 - [Project Management](https://wiki.gnome.org/Apps/Planner) (plan projects)
+- [GNote](https://wiki.gnome.org/Apps/Gnote) (write short sticky-notes of information)
+- [gedit](http://www.gedit.org) (Under the name "Text Editor")
 
 <a name="image-editor"></a>
 ## Image Editor 
 **PURPOSE**: I Need to Touch Up Some Photos
 - [GIMP](https://www.gimp.org/)
+- [Darktable](http://www.darktable.org/) (Photography and RAW photo developer)
 - [Inkscape](https://inkscape.org/) (Vector graphics editor)
 - [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
 
 <a name="image-viewers"></a>
 ## Image Viewers
 **PURPOSE**: I Just Want to Look at Some Photos
+- [Eye of GNOME](https://wiki.gnome.org/Apps/EyeOfGnome) (Under the name "Image Viewer")
+- [Shotwell](https://wiki.gnome.org/Apps/Shotwell) (Photo Manger)
 
 <a name="pdf-readers"></a>
 ## PDF Readers
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="e-readers"></a>
 ## E-Readers 
+- [FBReader](https://fbreader.org/) (E-book and Comic Book reader)
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="rss-reader"></a>
 ## RSS Reader
+- [Liferea](http://lzone.de/liferea/)
 
 <a name="scanners"></a>
 ## Scanners 
 **PURPOSE**: I Need to Scan a Document
+- [Simple Scan](https://launchpad.net/simple-scan)
 
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
 - [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
+- [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox/) (Audio player)
 
 <a name="multimedia-ripping-and-conversion"></a>
 ## Multimedia Ripping and Conversion
 **PURPOSE**: I Need to Rip My CD or DVD
+- [Brasero](https://wiki.gnome.org/Apps/Brasero) (copies and burns CDs and DVDs)
 - [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blurays)
+- [Sound Juicer](https://wiki.gnome.org/Apps/SoundJuicer) (rips audio CDs to your hard-drive)
+- [Sound Converter](http://soundconverter.org) (Converts audio files to other formats)
 
 <a name="desktop-recording"></a>
 ## Desktop Recording
@@ -93,6 +94,7 @@ Because of KDE's significant differences, we cannot list many packages on this p
 <a name="sound-and-video-editing"></a>
 ## Sound and Video Editing
 - [Audacity](http://www.audacityteam.org/) (audio editing program)
+- [Pitivi](http://www.pitivi.org/) (video editing program)
 
 <a name="internet"></a>
 ## Internet
@@ -100,17 +102,24 @@ Because of KDE's significant differences, we cannot list many packages on this p
 
 <a name="e-mail"></a>
 ## E-Mail
+- [Evolution](https://wiki.gnome.org/Apps/Evolution)
 
 <a name="audiovisual-communication"></a>
 ## Audiovisual Communication
 **PURPOSE**: I Need to Call / Video Conference With Someone
+- [Ekiga Softphone](http://www.ekiga.org)
 
 <a name="chat-applications"></a>
 ## Chat Applications
+- [Empathy](https://wiki.gnome.org/Apps/Empathy) (IM app, has compatibility with AIM, Google Talk, XMPP, etc.)
+- [HexChat](https://hexchat.github.io/) (IRC Client)
 
 <a name="torrent-client"></a>
 ## Torrent Client
+- [Transmission](http://www.transmissionbt.com/)
 
 <a name="system-applications"></a>
 ## System Applications
+- [GParted](http://gparted.org) (Modify and delete system partitions)
+- [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)

--- a/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
@@ -1,0 +1,133 @@
+**Table of Contents**  
+
+- [Tour of KDE Software ("I Need a Program That Does This")](#tour-of-kde-software-i-need-a-program-that-does-this)
+- [Office Applications](#office-applications)
+- [Image Editor](#image-editor)
+- [Image Viewers](#image-viewers)
+- [PDF Readers](#pdf-readers)
+- [E-Readers](#e-readers)
+- [RSS Reader](#rss-reader)
+- [Scanners](#scanners)
+- [Multimedia Players](#multimedia-players)
+- [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
+- [Desktop Recording](#desktop-recording)
+- [Sound and Video Editing](#sound-and-video-editing)
+- [Internet](#internet)
+- [E-Mail](#e-mail)
+- [Audiovisual Communication](#audiovisual-communication)
+- [Chat Applications](#chat-applications)
+- [Torrent Client](#torrent-client)
+- [System Applications](#system-applications)
+
+
+
+<a name="tour-of-kde-software-i-need-a-program-that-does-this"></a>
+# Tour of KDE Software ("I Need a Program That Does This")
+
+One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
+
+The KDE Desktop pulls its preloaded applications from [The KDE Project](https://www.kde.org/), the maintainers of KDE. Almost all KDE applications are developed in-house and **do not** pull in many GNOME apps, as some other distributions do. The KDE desktop has a sizable number of KDE and Qt libraries, and tends to favor applications that are optimized for use with those libraries.
+
+A handful of extra packages are added by Korora.
+
+<a name="office-applications"></a>
+## Office Applications
+**PURPOSE**: I Need To Edit Some Documents
+- [LibreOffice Writer](https://www.libreoffice.org/discover/writer/) (Document Editor, like Microsoft Word)
+- [LibreOffice Calc](https://www.libreoffice.org/discover/calc/) (Spreadsheet editor, like Microsoft Excel)
+- [LibreOffice Draw](https://www.libreoffice.org/discover/draw/) (Image and flowchart editor, like Microsoft Visio)
+- [LibreOffice Impress](https://www.libreoffice.org/discover/impress/) (Presentation and slide editor, like Microsoft Powerpoint)
+- [Project Management](https://wiki.gnome.org/Apps/Planner) (plan projects)
+- [KJots](https://userbase.kde.org/KJots) (write short sticky-notes of information) (Under the name "Note Taker")
+- [KWrite](https://www.kde.org/applications/utilities/kwrite/) (Text Editor; supports syntax highlighting for code)
+
+<a name="image-editor"></a>
+## Image Editor 
+**PURPOSE**: I Need to Touch Up Some Photos
+- [KolourPaint](http://www.kolourpaint.org/) (A simple image editor in the vein of MS-Paint)
+- [GIMP](https://www.gimp.org/)
+- [Darktable](http://www.darktable.org/) (Photography and RAW photo developer)
+- [Inkscape](https://inkscape.org/) (Vector graphics editor)
+- [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
+
+<a name="image-viewers"></a>
+## Image Viewers
+**PURPOSE**: I Just Want to Look at Some Photos
+- [Gwenview](https://userbase.kde.org/Gwenview) (Under the name "KDE Image Viewer")
+- [digiKam](https://digikam.org/) (Photo Manger) (Under the name "Photo Management Program")
+- [showFoto](https://docs.kde.org/trunk5/en/extragear-graphics/showfoto/index.html) (Photo Manger/Editor) (Under the name "Photo Viewer and Editor")
+
+<a name="pdf-readers"></a>
+## PDF Readers
+- [Okular](http://okular.kde.org) (Under the name "Document Viewer")
+
+<a name="e-readers"></a>
+## E-Readers 
+- [calibre](https://calibre-ebook.com/) (E-book reader)
+- [Okular](http://okular.kde.org) (Under the name "Document Viewer")
+
+<a name="rss-reader"></a>
+## RSS Reader
+- [Akregator](https://userbase.kde.org/Akregator) (Under the name "Feed Reader")
+- [KNode](https://www.kde.org/applications/internet/knode/) (Under the name "News Reader")
+
+<a name="scanners"></a>
+## Scanners 
+**PURPOSE**: I Need to Scan a Document
+- [Skanlite](https://www.kde.org/applications/graphics/skanlite/)
+
+<a name="multimedia-players"></a>
+## Multimedia Players
+**PURPOSE**: I Need to Play Some Music or Video
+- [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
+- [Amarok](http://amarok.kde.org) (Audio player)
+
+<a name="multimedia-ripping-and-conversion"></a>
+## Multimedia Ripping and Conversion
+**PURPOSE**: I Need to Rip My CD or DVD
+- [K3b](http://www.k3b.org) (copies and burns CDs, DVDs, and Blu-rays)
+- [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blu-rays)
+- [KAudioCreator](http://kde-apps.org/content/show.php/KAudioCreator?content=107645) (rips audio CDs to your hard-drive) (Under the name "CD Ripper")
+- [soundKonvertor](https://github.com/dfaust/soundkonverter) (Converts audio files to other formats)
+
+<a name="desktop-recording"></a>
+## Desktop Recording
+- [recordMyDesktop](https://sourceforge.net/projects/recordmydesktop/)
+
+<a name="sound-and-video-editing"></a>
+## Sound and Video Editing
+- [Audacity](http://www.audacityteam.org/) (audio editing program)
+- [Kdenlive](https://kdenlive.org/) (video editing program)
+
+<a name="internet"></a>
+## Internet
+- [Firefox](https://www.mozilla.org/en-US/firefox/)
+- [Konqueror](http://konqueror.kde.org) (KDE Default browser; also doubles as a file manager)
+- [Qupzilla](https://www.qupzilla.com/) (A lightweight browser written with Qt)
+
+<a name="e-mail"></a>
+## E-Mail
+- [KMail](https://www.kde.org/applications/internet/kmail/) (Under the name "Mail Client")
+
+<a name="audiovisual-communication"></a>
+## Audiovisual Communication
+**PURPOSE**: I Need to Call / Video Conference With Someone
+- [Linphone](http://www.linphone.org)
+
+<a name="chat-applications"></a>
+## Chat Applications
+- [KDE Telepathy](https://userbase.kde.org/Telepathy) (Under the name "IM Contacts")
+- [Konversation](http://konversation.kde.org/) (IRC Client)
+
+<a name="torrent-client"></a>
+## Torrent Client
+- [KTorrent](http://www.ktorrent.org/)
+
+<a name="system-applications"></a>
+## System Applications
+- [KDE Partition Manager](https://www.kde.org/applications/system/kdepartitionmanager/) (Modify and delete system partitions)
+- [Back in Time](https://github.com/bit-team/backintime) (Create a backup of your system)
+- [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+- [Storage Service Manager](https://github.com/KDE/pim-storage-service-manager) (Under the name "Cloud Storage Manager")
+- [Krfb](https://www.kde.org/applications/system/krfb/) (Under the name "KDE Desktop Sharing")
+- [KRDC](https://www.kde.org/applications/internet/krdc/) (Under the name "KDE Remote Desktop Client")

--- a/UsingKorora/DesktopSpecific/MATE-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/MATE-Tour-of-Software.md
@@ -1,7 +1,6 @@
 **Table of Contents**  
 
-- [Tour of Korora Software ("I Need a Program That Does This")](#tour-of-korora-software-i-need-a-program-that-does-this)
-- [Common Packages and Desktop Differences](#common-packages-and-desktop-differences)
+- [Tour of MATE Software ("I Need a Program That Does This")](#tour-of-mate-software-i-need-a-program-that-does-this)
 - [Office Applications](#office-applications)
 - [Image Editor](#image-editor)
 - [Image Viewers](#image-viewers)
@@ -22,26 +21,14 @@
 
 
 
-<a name="tour-of-korora-software-i-need-a-program-that-does-this"></a>
-# Tour of Korora Software ("I Need a Program That Does This")
+<a name="tour-of-mate-software-i-need-a-program-that-does-this"></a>
+# Tour of MATE Software ("I Need a Program That Does This")
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
-<a name="common-packages-and-desktop-differences"></a>
-## Common Packages and Desktop Differences
+The MATE Desktop largely uses GNOME applications for its inventory of existing programs. However, as MATE is itself a fork of GNOME 2, MATE maintains several forks of GNOME apps in order to better maintain their aesthetic within the classic GNOME 2/desktop paradigm. These include MATE's own Image Viewer and Document Viewer, based on upstream GNOME programs.
 
-Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
-
-**GTK-based desktops**:
-- [GNOME](GNOME-Tour-of-Software.md)
-- [Cinnamon](Cinnamon-Tour-of-Software.md)
-- [MATE](MATE-Tour-of-Software.md)
-- [Xfce](Xfce-Tour-of-Software.md)
-
-**Qt-based desktops**:
-- [KDE](KDE-Tour-of-Software.md)
-
-Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
+On top of this, there are additional packages added by Korora.
 
 <a name="office-applications"></a>
 ## Office Applications
@@ -51,6 +38,8 @@ Because of KDE's significant differences, we cannot list many packages on this p
 - [LibreOffice Draw](https://www.libreoffice.org/discover/draw/) (Image and flowchart editor, like Microsoft Visio)
 - [LibreOffice Impress](https://www.libreoffice.org/discover/impress/) (Presentation and slide editor, like Microsoft Powerpoint)
 - [Project Management](https://wiki.gnome.org/Apps/Planner) (plan projects)
+- [GNote](https://wiki.gnome.org/Apps/Gnote) (write short sticky-notes of information)
+- [Pluma](https://github.com/mate-desktop/pluma)
 
 <a name="image-editor"></a>
 ## Image Editor 
@@ -58,33 +47,45 @@ Because of KDE's significant differences, we cannot list many packages on this p
 - [GIMP](https://www.gimp.org/)
 - [Inkscape](https://inkscape.org/) (Vector graphics editor)
 - [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
+- [MATE Color Selection](http://mate-desktop.org/)
 
 <a name="image-viewers"></a>
 ## Image Viewers
 **PURPOSE**: I Just Want to Look at Some Photos
+- [Eye of MATE Image Viewer](https://github.com/mate-desktop/eom)
+- [Shotwell](https://wiki.gnome.org/Apps/Shotwell) (Photo Manger)
 
 <a name="pdf-readers"></a>
 ## PDF Readers
+- [Atril Document Viewer](https://github.com/mate-desktop/atril) (Fork of Evince)
 
 <a name="e-readers"></a>
 ## E-Readers 
+- [FBReader](https://fbreader.org/) (E-book and Comic Book reader)
+- [Atril Document Viewer](https://github.com/mate-desktop/atril) (Fork of Evince)
 
 <a name="rss-reader"></a>
 ## RSS Reader
+- [Liferea](http://lzone.de/liferea/)
 
 <a name="scanners"></a>
 ## Scanners 
 **PURPOSE**: I Need to Scan a Document
+- [Simple Scan](https://launchpad.net/simple-scan)
 
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
 - [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
+- [Audacious](http://audacious-media-player.org) (Audio player)
 
 <a name="multimedia-ripping-and-conversion"></a>
 ## Multimedia Ripping and Conversion
 **PURPOSE**: I Need to Rip My CD or DVD
+- [Asunder CD Ripper](http://littlesvr.ca/asunder/)
 - [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blurays)
+- [Sound Converter](http://soundconverter.org) (Converts audio files to other formats)
+- [Xfburn](http://www.xfce.org/projects/xfburn) (CD Burner)
 
 <a name="desktop-recording"></a>
 ## Desktop Recording
@@ -93,6 +94,7 @@ Because of KDE's significant differences, we cannot list many packages on this p
 <a name="sound-and-video-editing"></a>
 ## Sound and Video Editing
 - [Audacity](http://www.audacityteam.org/) (audio editing program)
+- [Pitivi](http://www.pitivi.org/) (video editing program)
 
 <a name="internet"></a>
 ## Internet
@@ -100,17 +102,24 @@ Because of KDE's significant differences, we cannot list many packages on this p
 
 <a name="e-mail"></a>
 ## E-Mail
+- [Thunderbird](https://www.mozilla.org/en-US/thunderbird/)
 
 <a name="audiovisual-communication"></a>
 ## Audiovisual Communication
 **PURPOSE**: I Need to Call / Video Conference With Someone
+- [Ekiga Softphone](http://www.ekiga.org)
 
 <a name="chat-applications"></a>
 ## Chat Applications
+- [Pidgin](https://pidgin.im/) (IM app, has compatibility with AIM, Google Talk, XMPP, etc.)
+- [HexChat](https://hexchat.github.io/) (IRC Client)
 
 <a name="torrent-client"></a>
 ## Torrent Client
+- [Transmission](http://www.transmissionbt.com/)
 
 <a name="system-applications"></a>
 ## System Applications
+- [GParted](http://gparted.org) (Modify and delete system partitions)
+- [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)

--- a/UsingKorora/DesktopSpecific/Xfce-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/Xfce-Tour-of-Software.md
@@ -1,7 +1,6 @@
 **Table of Contents**  
 
-- [Tour of Korora Software ("I Need a Program That Does This")](#tour-of-korora-software-i-need-a-program-that-does-this)
-- [Common Packages and Desktop Differences](#common-packages-and-desktop-differences)
+- [Tour of Xfce Software ("I Need a Program That Does This")](#tour-of-xfce-software-i-need-a-program-that-does-this)
 - [Office Applications](#office-applications)
 - [Image Editor](#image-editor)
 - [Image Viewers](#image-viewers)
@@ -22,26 +21,14 @@
 
 
 
-<a name="tour-of-korora-software-i-need-a-program-that-does-this"></a>
-# Tour of Korora Software ("I Need a Program That Does This")
+<a name="tour-of-xfce-software-i-need-a-program-that-does-this"></a>
+# Tour of Xfce Software ("I Need a Program That Does This")
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
-<a name="common-packages-and-desktop-differences"></a>
-## Common Packages and Desktop Differences
+Xfce largely uses GNOME apps among its inventory of preinstalled applications. However, a handful of Xfce-specific applications are used as well, such as Xfce's in-house image viewer, ristretto.
 
-Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
-
-**GTK-based desktops**:
-- [GNOME](GNOME-Tour-of-Software.md)
-- [Cinnamon](Cinnamon-Tour-of-Software.md)
-- [MATE](MATE-Tour-of-Software.md)
-- [Xfce](Xfce-Tour-of-Software.md)
-
-**Qt-based desktops**:
-- [KDE](KDE-Tour-of-Software.md)
-
-Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
+On top of this, there are additional packages added by Korora.
 
 <a name="office-applications"></a>
 ## Office Applications
@@ -57,34 +44,44 @@ Because of KDE's significant differences, we cannot list many packages on this p
 **PURPOSE**: I Need to Touch Up Some Photos
 - [GIMP](https://www.gimp.org/)
 - [Inkscape](https://inkscape.org/) (Vector graphics editor)
-- [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
 
 <a name="image-viewers"></a>
 ## Image Viewers
 **PURPOSE**: I Just Want to Look at Some Photos
+- [ristretto](http://goodies.xfce.org/projects/applications/ristretto) (Under the name "Ristretto Image Viewer")
+- [Shotwell](https://wiki.gnome.org/Apps/Shotwell) (Photo Manger)
 
 <a name="pdf-readers"></a>
 ## PDF Readers
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="e-readers"></a>
 ## E-Readers 
+- [FBReader](https://fbreader.org/) (E-book and Comic Book reader)
+- [Evince](https://wiki.gnome.org/Apps/Evince) (Under the name "Document Viewer")
 
 <a name="rss-reader"></a>
 ## RSS Reader
+- [Liferea](http://lzone.de/liferea/)
 
 <a name="scanners"></a>
 ## Scanners 
 **PURPOSE**: I Need to Scan a Document
+- [Simple Scan](https://launchpad.net/simple-scan)
 
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
 - [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
+- [Audacious](http://audacious-media-player.org) (Audio player)
 
 <a name="multimedia-ripping-and-conversion"></a>
 ## Multimedia Ripping and Conversion
 **PURPOSE**: I Need to Rip My CD or DVD
+- [Asunder CD Ripper](http://littlesvr.ca/asunder/)
 - [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blurays)
+- [Sound Converter](http://soundconverter.org) (Converts audio files to other formats)
+- [Xfburn](http://www.xfce.org/projects/xfburn) (CD Burner)
 
 <a name="desktop-recording"></a>
 ## Desktop Recording
@@ -93,6 +90,7 @@ Because of KDE's significant differences, we cannot list many packages on this p
 <a name="sound-and-video-editing"></a>
 ## Sound and Video Editing
 - [Audacity](http://www.audacityteam.org/) (audio editing program)
+- [Pitivi](http://www.pitivi.org/) (video editing program)
 
 <a name="internet"></a>
 ## Internet
@@ -100,17 +98,24 @@ Because of KDE's significant differences, we cannot list many packages on this p
 
 <a name="e-mail"></a>
 ## E-Mail
+- [Thunderbird](https://www.mozilla.org/en-US/thunderbird/)
 
 <a name="audiovisual-communication"></a>
 ## Audiovisual Communication
 **PURPOSE**: I Need to Call / Video Conference With Someone
+- [Ekiga Softphone](http://www.ekiga.org)
 
 <a name="chat-applications"></a>
 ## Chat Applications
+- [Pidgin](https://pidgin.im/) (IM app, has compatibility with AIM, Google Talk, XMPP, etc.)
+- [HexChat](https://hexchat.github.io/) (IRC Client)
 
 <a name="torrent-client"></a>
 ## Torrent Client
+- [Transmission](http://www.transmissionbt.com/)
 
 <a name="system-applications"></a>
 ## System Applications
+- [GParted](http://gparted.org) (Modify and delete system partitions)
+- [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)


### PR DESCRIPTION
This pull expands the original Tour of Korora Software article into five separate articles tailored to each specific desktop environment.

The original page now serves as a landing page to link to each specific DE page. It also includes some packages that are available across all five desktops, although this information can be removed if we do not feel it is sufficiently useful to display.