### PR TITLE
Drop Common Packages from Software Tour article

### DIFF
--- a/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
@@ -1,6 +1,6 @@
 **Table of Contents**  
 
-- [Tour of KDE Software ("I Need a Program That Does This")](#tour-of-kde-software-i-need-a-program-that-does-this)
+- [Tour of KDE Plasma Software ("I Need a Program That Does This")](#tour-of-kde-plasma-software-i-need-a-program-that-does-this)
 - [Office Applications](#office-applications)
 - [Image Editor](#image-editor)
 - [Image Viewers](#image-viewers)
@@ -22,11 +22,11 @@
 
 
 <a name="tour-of-kde-software-i-need-a-program-that-does-this"></a>
-# Tour of KDE Software ("I Need a Program That Does This")
+# Tour of KDE Plasma Software ("I Need a Program That Does This")
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
-The KDE Desktop pulls its preloaded applications from [The KDE Project](https://www.kde.org/), the maintainers of KDE. Almost all KDE applications are developed in-house and **do not** pull in many GNOME apps, as some other distributions do. The KDE desktop has a sizable number of KDE and Qt libraries, and tends to favor applications that are optimized for use with those libraries.
+The KDE Plasma Desktop pulls its preloaded applications from [The KDE Project](https://www.kde.org/), the maintainers of KDE. Almost all KDE applications are developed in-house and **do not** pull in many GNOME apps, as some other distributions do. The KDE desktop has a sizable number of KDE and Qt libraries, and tends to favor applications that are optimized for use with those libraries.
 
 A handful of extra packages are added by Korora.
 

--- a/UsingKorora/General/Tour-of-Korora-Software.md
+++ b/UsingKorora/General/Tour-of-Korora-Software.md
@@ -1,116 +1,30 @@
 **Table of Contents**  
 
-- [Tour of Korora Software ("I Need a Program That Does This")](#tour-of-korora-software-i-need-a-program-that-does-this)
+- [Tour of Korora Software](#tour-of-korora-software)
 - [Common Packages and Desktop Differences](#common-packages-and-desktop-differences)
-- [Office Applications](#office-applications)
-- [Image Editor](#image-editor)
-- [Image Viewers](#image-viewers)
-- [PDF Readers](#pdf-readers)
-- [E-Readers](#e-readers)
-- [RSS Reader](#rss-reader)
-- [Scanners](#scanners)
-- [Multimedia Players](#multimedia-players)
-- [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
-- [Desktop Recording](#desktop-recording)
-- [Sound and Video Editing](#sound-and-video-editing)
-- [Internet](#internet)
-- [E-Mail](#e-mail)
-- [Audiovisual Communication](#audiovisual-communication)
-- [Chat Applications](#chat-applications)
-- [Torrent Client](#torrent-client)
-- [System Applications](#system-applications)
+- [GTK-based desktops](#gtk-based-desktops)
+- [Qt-based desktops](#qt-based-desktops)
 
-
-
-<a name="tour-of-korora-software-i-need-a-program-that-does-this"></a>
-# Tour of Korora Software ("I Need a Program That Does This")
+<a name="tour-of-korora-software"></a>
+# Tour of Korora Software
 
 One of the core aims of the Korora Project is to provide an out-of-box Linux experience that can take care of the average's users daily needs with entirely free software. To save you the trouble of digging through every preinstalled application, we have compiled a list of the prepackaged applications within each version of Korora that fulfill a specific purpose. This will hopefully save you some trouble from immediately downloading more software when the right tool may already be installed.
 
 <a name="common-packages-and-desktop-differences"></a>
 ## Common Packages and Desktop Differences
 
-Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
+Of the five supported desktop environments for Korora, four of them are GNOME/GTK-based. As a result, they carry many packages inherited upstream from GNOME. The fifth desktop environment, KDE Plasma, has its own suite of applications and diverges heavily from the rest. The KDE applications tend to use the [Qt](https://en.wikipedia.org/wiki/Qt_(software)) framework rather than [GTK](https://en.wikipedia.org/wiki/GTK%2B).
 
-**GTK-based desktops**:
+Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
+
+<a name="gtk-based-desktops"></a>
+## GTK-based desktops
+
 - [GNOME](GNOME-Tour-of-Software.md)
 - [Cinnamon](Cinnamon-Tour-of-Software.md)
 - [MATE](MATE-Tour-of-Software.md)
 - [Xfce](Xfce-Tour-of-Software.md)
 
-**Qt-based desktops**:
-- [KDE](KDE-Tour-of-Software.md)
-
-Because of KDE's significant differences, we cannot list many packages on this page that are truly common between all five DE's. However, some do exist, including those that are added by Korora. They are listed below. For the packages that are included in each specific desktop, please visit the page for that particular desktop environment.
-
-<a name="office-applications"></a>
-## Office Applications
-**PURPOSE**: I Need To Edit Some Documents
-- [LibreOffice Writer](https://www.libreoffice.org/discover/writer/) (Document Editor, like Microsoft Word)
-- [LibreOffice Calc](https://www.libreoffice.org/discover/calc/) (Spreadsheet editor, like Microsoft Excel)
-- [LibreOffice Draw](https://www.libreoffice.org/discover/draw/) (Image and flowchart editor, like Microsoft Visio)
-- [LibreOffice Impress](https://www.libreoffice.org/discover/impress/) (Presentation and slide editor, like Microsoft Powerpoint)
-- [Project Management](https://wiki.gnome.org/Apps/Planner) (plan projects)
-
-<a name="image-editor"></a>
-## Image Editor 
-**PURPOSE**: I Need to Touch Up Some Photos
-- [GIMP](https://www.gimp.org/)
-- [Inkscape](https://inkscape.org/) (Vector graphics editor)
-- [Cura LulzBot Edition](https://www.lulzbot.com/cura) (3D Printing software)
-
-<a name="image-viewers"></a>
-## Image Viewers
-**PURPOSE**: I Just Want to Look at Some Photos
-
-<a name="pdf-readers"></a>
-## PDF Readers
-
-<a name="e-readers"></a>
-## E-Readers 
-
-<a name="rss-reader"></a>
-## RSS Reader
-
-<a name="scanners"></a>
-## Scanners 
-**PURPOSE**: I Need to Scan a Document
-
-<a name="multimedia-players"></a>
-## Multimedia Players
-**PURPOSE**: I Need to Play Some Music or Video
-- [VLC](http://www.videolan.org/) (Audio and Video player; supports most multimedia formats with no additional codecs)
-
-<a name="multimedia-ripping-and-conversion"></a>
-## Multimedia Ripping and Conversion
-**PURPOSE**: I Need to Rip My CD or DVD
-- [Handbrake](https://handbrake.fr) (Transcodes CDs, DVDs, and Blurays)
-
-<a name="desktop-recording"></a>
-## Desktop Recording
-- [recordMyDesktop](https://sourceforge.net/projects/recordmydesktop/)
-
-<a name="sound-and-video-editing"></a>
-## Sound and Video Editing
-- [Audacity](http://www.audacityteam.org/) (audio editing program)
-
-<a name="internet"></a>
-## Internet
-- [Firefox](https://www.mozilla.org/en-US/firefox/)
-
-<a name="e-mail"></a>
-## E-Mail
-
-<a name="audiovisual-communication"></a>
-## Audiovisual Communication
-**PURPOSE**: I Need to Call / Video Conference With Someone
-
-<a name="chat-applications"></a>
-## Chat Applications
-
-<a name="torrent-client"></a>
-## Torrent Client
-
-<a name="system-applications"></a>
-## System Applications
-- [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+<a name="gtk-based-desktops"></a>
+## Qt-based desktops
+- [KDE Plasma](KDE-Tour-of-Software.md)

--- a/UsingKorora/General/Tour-of-Korora-Software.md
+++ b/UsingKorora/General/Tour-of-Korora-Software.md
@@ -20,11 +20,11 @@ Because of KDE's significant differences, we cannot list many packages on this p
 <a name="gtk-based-desktops"></a>
 ## GTK-based desktops
 
-- [GNOME](GNOME-Tour-of-Software.md)
-- [Cinnamon](Cinnamon-Tour-of-Software.md)
-- [MATE](MATE-Tour-of-Software.md)
-- [Xfce](Xfce-Tour-of-Software.md)
+- [GNOME](../DesktopSpecific/GNOME-Tour-of-Software.md)
+- [Cinnamon](../DesktopSpecific/Cinnamon-Tour-of-Software.md)
+- [MATE](../DesktopSpecific/MATE-Tour-of-Software.md)
+- [Xfce](../DesktopSpecific/Xfce-Tour-of-Software.md)
 
 <a name="gtk-based-desktops"></a>
 ## Qt-based desktops
-- [KDE Plasma](KDE-Tour-of-Software.md)
+- [KDE Plasma](../DesktopSpecific/KDE-Tour-of-Software.md)


### PR DESCRIPTION
This pull drops the common packages section from the main Korora Software Tour article, per request from @jimkp. 

"KDE" is now referred to as "KDE Plasma" in the context of the desktop environment.

Links are fixed so that the DE links will actually take you to the DE pages.