### PR TITLE
Add screenshooters and color temperature tools.

### DIFF
--- a/UsingKorora/DesktopSpecific/Cinnamon-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/Cinnamon-Tour-of-Software.md
@@ -8,6 +8,7 @@
 - [E-Readers](#e-readers)
 - [RSS Reader](#rss-reader)
 - [Scanners](#scanners)
+- [Screen Capture Tools](#screen-capture-tools)
 - [Multimedia Players](#multimedia-players)
 - [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
 - [Desktop Recording](#desktop-recording)
@@ -70,6 +71,11 @@ The Cinnamon desktop pulls most of its preinstalled programs from GNOME, with a 
 **PURPOSE**: I Need to Scan a Document
 - [Simple Scan](https://launchpad.net/simple-scan)
 
+<a name="screen-capture-tools"></a>
+## Screen Capture Tools
+**PURPOSE**: I Need to Take a Screenshot
+- [gnome-screenshot](https://git.gnome.org/browse/gnome-screenshot/) (Under the name "Screenshot") 
+
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
@@ -120,3 +126,4 @@ The Cinnamon desktop pulls most of its preinstalled programs from GNOME, with a 
 - [GParted](http://gparted.org) (Modify and delete system partitions)
 - [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+- [Redshift](http://jonls.dk/redshift/) (Screen temperature adjustment / blue-light reduction tool)

--- a/UsingKorora/DesktopSpecific/GNOME-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/GNOME-Tour-of-Software.md
@@ -8,6 +8,7 @@
 - [E-Readers](#e-readers)
 - [RSS Reader](#rss-reader)
 - [Scanners](#scanners)
+- [Screen Capture Tools](#screen-capture-tools)
 - [Multimedia Players](#multimedia-players)
 - [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
 - [Desktop Recording](#desktop-recording)
@@ -73,6 +74,11 @@ On top of this, there are additional packages added by Korora.
 **PURPOSE**: I Need to Scan a Document
 - [Simple Scan](https://launchpad.net/simple-scan)
 
+<a name="screen-capture-tools"></a>
+## Screen Capture Tools
+**PURPOSE**: I Need to Take a Screenshot
+- [gnome-screenshot](https://git.gnome.org/browse/gnome-screenshot/) (Under the name "Screenshot") 
+
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
@@ -123,3 +129,4 @@ On top of this, there are additional packages added by Korora.
 - [GParted](http://gparted.org) (Modify and delete system partitions)
 - [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+- [Redshift](http://jonls.dk/redshift/) (Screen temperature adjustment / blue-light reduction tool)

--- a/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/KDE-Tour-of-Software.md
@@ -8,6 +8,7 @@
 - [E-Readers](#e-readers)
 - [RSS Reader](#rss-reader)
 - [Scanners](#scanners)
+- [Screen Capture Tools](#screen-capture-tools)
 - [Multimedia Players](#multimedia-players)
 - [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
 - [Desktop Recording](#desktop-recording)
@@ -75,6 +76,11 @@ A handful of extra packages are added by Korora.
 ## Scanners 
 **PURPOSE**: I Need to Scan a Document
 - [Skanlite](https://www.kde.org/applications/graphics/skanlite/)
+
+<a name="screen-capture-tools"></a>
+## Screen Capture Tools
+**PURPOSE**: I Need to Take a Screenshot
+- [Spectacle](https://www.kde.org/applications/graphics/spectacle/)
 
 <a name="multimedia-players"></a>
 ## Multimedia Players

--- a/UsingKorora/DesktopSpecific/MATE-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/MATE-Tour-of-Software.md
@@ -8,6 +8,7 @@
 - [E-Readers](#e-readers)
 - [RSS Reader](#rss-reader)
 - [Scanners](#scanners)
+- [Screen Capture Tools](#screen-capture-tools)
 - [Multimedia Players](#multimedia-players)
 - [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
 - [Desktop Recording](#desktop-recording)
@@ -73,6 +74,11 @@ On top of this, there are additional packages added by Korora.
 **PURPOSE**: I Need to Scan a Document
 - [Simple Scan](https://launchpad.net/simple-scan)
 
+<a name="screen-capture-tools"></a>
+## Screen Capture Tools
+**PURPOSE**: I Need to Take a Screenshot
+- [mate-screenshot](https://github.com/mate-desktop/mate-utils) (Under the name "Take Screenshot")
+
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
@@ -123,3 +129,4 @@ On top of this, there are additional packages added by Korora.
 - [GParted](http://gparted.org) (Modify and delete system partitions)
 - [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+- [Redshift](http://jonls.dk/redshift/) (Screen temperature adjustment / blue-light reduction tool)

--- a/UsingKorora/DesktopSpecific/Xfce-Tour-of-Software.md
+++ b/UsingKorora/DesktopSpecific/Xfce-Tour-of-Software.md
@@ -8,6 +8,7 @@
 - [E-Readers](#e-readers)
 - [RSS Reader](#rss-reader)
 - [Scanners](#scanners)
+- [Screen Capture Tools](#screen-capture-tools)
 - [Multimedia Players](#multimedia-players)
 - [Multimedia Ripping and Conversion](#multimedia-ripping-and-conversion)
 - [Desktop Recording](#desktop-recording)
@@ -69,6 +70,11 @@ On top of this, there are additional packages added by Korora.
 **PURPOSE**: I Need to Scan a Document
 - [Simple Scan](https://launchpad.net/simple-scan)
 
+<a name="screen-capture-tools"></a>
+## Screen Capture Tools
+**PURPOSE**: I Need to Take a Screenshot
+- [Xfce4 Screenshooter](http://goodies.xfce.org/projects/applications/xfce4-screenshooter) (Under the name "Screenshot")
+
 <a name="multimedia-players"></a>
 ## Multimedia Players
 **PURPOSE**: I Need to Play Some Music or Video
@@ -119,3 +125,4 @@ On top of this, there are additional packages added by Korora.
 - [GParted](http://gparted.org) (Modify and delete system partitions)
 - [Backups](https://launchpad.net/deja-dup) (Create a backup of your system)
 - [ownCloud](https://owncloud.org/) (Self-hosted file sync and share platform)
+- [Redshift](http://jonls.dk/redshift/) (Screen temperature adjustment / blue-light reduction tool)


### PR DESCRIPTION
This pull adds a section for screenshot capture apps.

It also adds Redshift to the DE's that carry it under System Applications. I did not feel it worthy of its own category at this time, as the feature will soon be built into both GNOME and Plasma directly.